### PR TITLE
Plasma Turret Anvatis in fleets + error fix

### DIFF
--- a/data/events.txt
+++ b/data/events.txt
@@ -109,6 +109,28 @@ mission "Moksha Neutrality"
 	on offer
 		event "moksha neutrality"
 		fail
+		
+mission "plasma turret available Anvatis"
+	landing
+	invisible
+	to offer
+		has "event: plasma turret available"
+	on offer
+		event "plasma turret available Anvatis"
+		fail
+
+event "plasma turret available Anvatis"
+	fleet "Small Free Worlds"
+		add variant 2
+			"Anvatis (Plasma Turret)"
+			
+	fleet "Large Free Worlds"
+		add variant 2
+			"Anvatis"
+			"Anvatis (Plasma Turret)" 2
+		add variant 1
+			"Bastion (Heavy)"
+			"Anvatis (Plasma Turret)"
 
 event "navy occupying the south border"
 	system "Albaldah"

--- a/data/variants.txt
+++ b/data/variants.txt
@@ -18,7 +18,7 @@ ship "Anvatis" "Anvatis (Particle)"
 		"RT-I Radiothermal" 2
 		"Supercapacitor"
 		"Water Coolant System"
-		"Cooling Duct"
+		"Cooling Ducts"
 		"D23-QP Shield Generator"
 		
 		"Greyhound Plasma Thruster"
@@ -90,7 +90,7 @@ ship "Anvatis" "Anvatis (Speedy)"
 		"RT-I Radiothermal" 2
 		"Supercapacitor"
 		"Water Coolant System"
-		"Cooling Duct"
+		"Cooling Ducts"
 		"D14-RN Shield Generator"
 		
 		"A370 Atomic Thruster"


### PR DESCRIPTION
Spawn "Anvatis (Plasma Turret)" in Small and Large Free Worlds fleet after plasma turret became available. Used mission to detect if the event has been triggered then trigger its own event to be backward compatible with saves that already went past that event.

Also fixed two Anvatis variant with errors.